### PR TITLE
Updates libwebsockets to version 3.0.0-r0

### DIFF
--- a/mqtt/Dockerfile
+++ b/mqtt/Dockerfile
@@ -19,7 +19,7 @@ RUN \
     nginx=1.14.2-r0 \
     lua-resty-http=0.12-r1 \
     nginx-mod-http-lua=1.14.2-r0 \
-    libwebsockets@legacy=2.4.0-r1 \
+    libwebsockets@legacy=3.0.0-r0 \
     mosquitto@legacy=1.4.15-r0 \
   \
   && curl -J -L -o /tmp/web.zip \


### PR DESCRIPTION

# Proposed Changes

This PR will update `libwebsockets` to version `3.0.0-r0`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
