### PR TITLE
⬆️ Upgrades mosquitto broker to v1.6.1

### DIFF
--- a/mqtt/Dockerfile
+++ b/mqtt/Dockerfile
@@ -14,7 +14,7 @@ COPY rootfs /
 # Versions
 ENV HIVEMQ='46338a633eb26bc9f6d8d8ff82f8f2aedc004a57' \
     LIBWEBSOCKETS='2.4.2' \
-    MOSQUITTO='1.5.8'
+    MOSQUITTO='1.6.1'
 
 # Setup base
 # hadolint ignore=DL3003


### PR DESCRIPTION
# Proposed Changes

https://mosquitto.org/blog/2019/04/version-1-6-released/
https://mosquitto.org/blog/2019/04/version-1-6-1-released/

<blockquote><div><img src="../../../../favicon-32x32.png" height="14"> Eclipse Mosquitto</div><div><strong><a href="https://mosquitto.org/blog/2019/04/version-1-6-released/">Version 1.6 released</a></strong></div><div>This is a feature release and represents a substantial amount of change in the
project. Since version 1.5, the overall code line count for the broker, library
and clients has increased by 37% to 28k. </div></blockquote>
<blockquote><div><img src="../../../../favicon-32x32.png" height="14"> Eclipse Mosquitto</div><div><strong><a href="https://mosquitto.org/blog/2019/04/version-1-6-1-released/">Version 1.6.1 released</a></strong></div><div>This is a minor service release. The fixes are only related to documentation
and the build process, and so is primarily of interest for people building
Mosquitto.
Broker

Document memory_limit option.</div></blockquote>